### PR TITLE
Remove Jest packages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,8 +31,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "react-app",
-      "react-app/jest"
+      "react-app"
     ]
   },
   "browserslist": {


### PR DESCRIPTION
For testing, we should use Cypress, not Jest (included in Create React App). 