### PR TITLE
fix: z-index of accounts dropdown

### DIFF
--- a/frontend/src/components/AccountsDropdown.tsx
+++ b/frontend/src/components/AccountsDropdown.tsx
@@ -13,7 +13,7 @@ export function AccountsDropdown() {
         value={account}
         onChange={(a) => { setAccount(a) }}
       >
-        <div className="relative">
+        <div className="relative z-10">
           <Listbox.Button 
             className={classNames(
               "relative w-full cursor-default rounded-lg bg-violet-900 py-2 pl-3 pr-10 text-left shadow-md",


### PR DESCRIPTION
This issue was mostly fixed in a recent commit. Just adding the z-index to make sure the menu covers the input fields.

(Also, my Dot Stash is not really there. Just an example :)

<img width="447" alt="Screen Shot 2023-06-06 at 6 45 48 PM" src="https://github.com/paritytech/link/assets/2101499/858dfdf3-3a09-44f0-815e-a189134a04f1">
