### PR TITLE
feat: link to ink! faucet with user account

### DIFF
--- a/frontend/src/components/NewUserGuide.tsx
+++ b/frontend/src/components/NewUserGuide.tsx
@@ -9,13 +9,13 @@ export const NewUserGuide = () => {
     <div className="text-xs text-gray-300 text-left">
       {account && !hasFunds && (
         <p className="max-w-lg mx-auto">
-          Your account balance is zero. To obtain Rococo testnet tokens (ROC) use the{" "}
+          Your account balance is zero. Get ROC tokens{" "}
             <a
-              href="https://use.ink/faucet"
+              href={`https://use.ink/faucet?acc=${account.address}`}
               rel="noopener noreferrer"
               target="_blank"
             >
-            Rococo Contracts Faucet
+              here
             </a>.
         </p>
       )}


### PR DESCRIPTION
[This PR](https://github.com/paritytech/ink-docs/pull/233) adds a query param to prepopulate the faucet input with an address. (At the time of this PR that feature has not been deployed yet)

This PR adds the user's account to the faucet link, and shortens the copy to make it more user friendly.

<img width="475" alt="Screen Shot 2023-06-06 at 7 32 53 PM" src="https://github.com/paritytech/link/assets/2101499/ab237326-28a9-4a38-b35c-62423a6bf435">
